### PR TITLE
[runtime] Refactor StreamingJobGraphGenerator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ChainedSourceInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ChainedSourceInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph.util;
+
+import org.apache.flink.streaming.api.graph.StreamConfig;
+
+public final class ChainedSourceInfo {
+    private final StreamConfig operatorConfig;
+    private final StreamConfig.SourceInputConfig inputConfig;
+
+    public ChainedSourceInfo(
+            StreamConfig operatorConfig, StreamConfig.SourceInputConfig inputConfig) {
+        this.operatorConfig = operatorConfig;
+        this.inputConfig = inputConfig;
+    }
+
+    public StreamConfig getOperatorConfig() {
+        return operatorConfig;
+    }
+
+    public StreamConfig.SourceInputConfig getInputConfig() {
+        return inputConfig;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/JobVertexBuildContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/JobVertexBuildContext.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph.util;
+
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class JobVertexBuildContext {
+
+    private final StreamGraph streamGraph;
+
+    /** The {@link OperatorChainInfo}s, key is the start node id of the chain. */
+    private final Map<Integer, OperatorChainInfo> chainInfos;
+
+    /** The {@link OperatorInfo}s, key is the id of the stream node. */
+    private final Map<Integer, OperatorInfo> operatorInfosInorder;
+
+    // The created JobVertex, the key is start node id
+    private final Map<Integer, JobVertex> jobVerticesInorder;
+
+    // the ids of nodes whose output result partition type should be set to BLOCKING
+    private final Set<Integer> outputBlockingNodesID;
+
+    // The order of StreamEdge connected to other vertices should be consistent with the order in
+    // which JobEdge was created
+    private final List<StreamEdge> physicalEdgesInOrder;
+
+    // In progressive generation mode, this boolean only contains information from the current stage
+    private boolean hasHybridResultPartition;
+
+    public JobVertexBuildContext(StreamGraph streamGraph) {
+        this.streamGraph = streamGraph;
+        this.chainInfos = new HashMap<>();
+        this.operatorInfosInorder = new LinkedHashMap<>();
+        this.jobVerticesInorder = new LinkedHashMap<>();
+        this.outputBlockingNodesID = new HashSet<>();
+        this.physicalEdgesInOrder = new ArrayList<>();
+        this.hasHybridResultPartition = false;
+    }
+
+    public void addChainInfo(Integer startNodeId, OperatorChainInfo chainInfo) {
+        chainInfos.put(startNodeId, chainInfo);
+    }
+
+    public OperatorChainInfo getChainInfo(Integer startNodeId) {
+        return chainInfos.get(startNodeId);
+    }
+
+    public Map<Integer, OperatorChainInfo> getChainInfos() {
+        return chainInfos;
+    }
+
+    public OperatorInfo getOperatorInfo(Integer nodeId) {
+        return operatorInfosInorder.get(nodeId);
+    }
+
+    public OperatorInfo getOrCreateOperatorInfo(Integer nodeId) {
+        return operatorInfosInorder.computeIfAbsent(nodeId, key -> new OperatorInfo());
+    }
+
+    public Map<Integer, OperatorInfo> getOperatorInfos() {
+        return operatorInfosInorder;
+    }
+
+    public StreamGraph getStreamGraph() {
+        return streamGraph;
+    }
+
+    public boolean hasHybridResultPartition() {
+        return hasHybridResultPartition;
+    }
+
+    public void setHasHybridResultPartition(boolean hasHybridResultPartition) {
+        this.hasHybridResultPartition = hasHybridResultPartition;
+    }
+
+    public void addPhysicalEdgesInOrder(StreamEdge edge) {
+        physicalEdgesInOrder.add(edge);
+    }
+
+    public List<StreamEdge> getPhysicalEdgesInOrder() {
+        return physicalEdgesInOrder;
+    }
+
+    public void addOutputBlockingNode(Integer nodeId) {
+        outputBlockingNodesID.add(nodeId);
+    }
+
+    public boolean isOutputBlockingNode(Integer nodeId) {
+        return outputBlockingNodesID.contains(nodeId);
+    }
+
+    public void addJobVertex(Integer startNodeId, JobVertex jobVertex) {
+        jobVerticesInorder.put(startNodeId, jobVertex);
+    }
+
+    public Map<Integer, JobVertex> getJobVertices() {
+        return jobVerticesInorder;
+    }
+
+    public JobVertex getJobVertex(Integer startNodeId) {
+        return jobVerticesInorder.get(startNodeId);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/OperatorChainInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/OperatorChainInfo.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph.util;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.jobgraph.InputOutputFormatContainer;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamNode;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A public class to help maintain the information of an operator chain */
+public class OperatorChainInfo {
+    private final Integer startNodeId;
+    private final Map<Integer, byte[]> hashes;
+    private final List<Map<Integer, byte[]>> legacyHashes;
+    private final Map<Integer, List<Tuple2<byte[], byte[]>>> chainedOperatorHashes;
+    private final Map<Integer, ChainedSourceInfo> chainedSources;
+    private final List<OperatorCoordinator.Provider> coordinatorProviders;
+    private final StreamGraph streamGraph;
+    private final List<StreamNode> chainedNodes;
+    private final List<StreamEdge> transitiveOutEdges;
+    private final List<StreamEdge> transitiveInEdges;
+
+    private InputOutputFormatContainer inputOutputFormatContainer = null;
+
+    public OperatorChainInfo(
+            int startNodeId,
+            Map<Integer, byte[]> hashes,
+            List<Map<Integer, byte[]>> legacyHashes,
+            Map<Integer, ChainedSourceInfo> chainedSources,
+            StreamGraph streamGraph) {
+        this.startNodeId = startNodeId;
+        this.hashes = hashes;
+        this.legacyHashes = legacyHashes;
+        this.chainedOperatorHashes = new HashMap<>();
+        this.coordinatorProviders = new ArrayList<>();
+        this.chainedSources = chainedSources;
+        this.streamGraph = streamGraph;
+        this.chainedNodes = new ArrayList<>();
+        this.transitiveOutEdges = new ArrayList<>();
+        this.transitiveInEdges = new ArrayList<>();
+    }
+
+    public byte[] getHash(Integer streamNodeId) {
+        return hashes.get(streamNodeId);
+    }
+
+    public Integer getStartNodeId() {
+        return startNodeId;
+    }
+
+    public List<Tuple2<byte[], byte[]>> getChainedOperatorHashes(int startNodeId) {
+        return chainedOperatorHashes.get(startNodeId);
+    }
+
+    public void addCoordinatorProvider(OperatorCoordinator.Provider coordinator) {
+        coordinatorProviders.add(coordinator);
+    }
+
+    public List<OperatorCoordinator.Provider> getCoordinatorProviders() {
+        return coordinatorProviders;
+    }
+
+    public Map<Integer, ChainedSourceInfo> getChainedSources() {
+        return chainedSources;
+    }
+
+    public OperatorID addNodeToChain(int currentNodeId, String operatorName) {
+        recordChainedNode(currentNodeId);
+        StreamNode streamNode = streamGraph.getStreamNode(currentNodeId);
+
+        List<Tuple2<byte[], byte[]>> operatorHashes =
+                chainedOperatorHashes.computeIfAbsent(startNodeId, k -> new ArrayList<>());
+
+        byte[] primaryHashBytes = hashes.get(currentNodeId);
+
+        for (Map<Integer, byte[]> legacyHash : legacyHashes) {
+            operatorHashes.add(new Tuple2<>(primaryHashBytes, legacyHash.get(currentNodeId)));
+        }
+
+        streamNode
+                .getCoordinatorProvider(operatorName, new OperatorID(getHash(currentNodeId)))
+                .map(coordinatorProviders::add);
+
+        return new OperatorID(primaryHashBytes);
+    }
+
+    public void setTransitiveOutEdges(final List<StreamEdge> transitiveOutEdges) {
+        this.transitiveOutEdges.addAll(transitiveOutEdges);
+    }
+
+    public List<StreamEdge> getTransitiveOutEdges() {
+        return transitiveOutEdges;
+    }
+
+    public void recordChainedNode(int currentNodeId) {
+        StreamNode streamNode = streamGraph.getStreamNode(currentNodeId);
+        chainedNodes.add(streamNode);
+    }
+
+    public OperatorChainInfo newChain(Integer startNodeId) {
+        return new OperatorChainInfo(
+                startNodeId, hashes, legacyHashes, chainedSources, streamGraph);
+    }
+
+    public List<StreamNode> getAllChainedNodes() {
+        return chainedNodes;
+    }
+
+    public boolean hasFormatContainer() {
+        return inputOutputFormatContainer != null;
+    }
+
+    public InputOutputFormatContainer getOrCreateFormatContainer() {
+        if (inputOutputFormatContainer == null) {
+            inputOutputFormatContainer =
+                    new InputOutputFormatContainer(Thread.currentThread().getContextClassLoader());
+        }
+        return inputOutputFormatContainer;
+    }
+
+    public void addChainedSource(Integer sourceNodeId, ChainedSourceInfo chainedSourceInfo) {
+        chainedSources.put(sourceNodeId, chainedSourceInfo);
+    }
+
+    public void addTransitiveInEdge(StreamEdge streamEdge) {
+        transitiveInEdges.add(streamEdge);
+    }
+
+    public List<StreamEdge> getTransitiveInEdges() {
+        return transitiveInEdges;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/OperatorInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/OperatorInfo.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph.util;
+
+import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A public class to help maintain the information of an operator */
+public class OperatorInfo {
+
+    private String chainedName;
+
+    private ResourceSpec chainedMinResource;
+
+    private ResourceSpec chainedPreferredResources;
+
+    private StreamConfig vertexConfig;
+
+    /**
+     * The config for node chained with the current operator, the key is the ID of the stream node
+     */
+    private final Map<Integer, StreamConfig> chainedConfigs;
+    /**
+     * This is used to cache the chainable outputs, to set the chainable outputs config after all
+     * job vertices are created.
+     */
+    private final List<StreamEdge> chainableOutputs;
+    /**
+     * This is used to cache the non-chainable outputs, to set the non-chainable outputs config
+     * after all job vertices are created.
+     */
+    private final List<StreamEdge> nonChainableOutputs;
+
+    public OperatorInfo() {
+        this.chainedConfigs = new HashMap<>();
+        this.chainableOutputs = new ArrayList<>();
+        this.nonChainableOutputs = new ArrayList<>();
+    }
+
+    public String getChainedName() {
+        return chainedName;
+    }
+
+    public void setChainedName(String chainedName) {
+        this.chainedName = chainedName;
+    }
+
+    public ResourceSpec getChainedMinResource() {
+        return chainedMinResource;
+    }
+
+    public void setChainedMinResource(ResourceSpec chainedMinResource) {
+        this.chainedMinResource = chainedMinResource;
+    }
+
+    public ResourceSpec getChainedPreferredResources() {
+        return chainedPreferredResources;
+    }
+
+    public void setChainedPreferredResources(ResourceSpec chainedPreferredResources) {
+        this.chainedPreferredResources = chainedPreferredResources;
+    }
+
+    public List<StreamEdge> getChainableOutputs() {
+        return chainableOutputs;
+    }
+
+    public void setChainableOutputs(List<StreamEdge> chainableOutputs) {
+        this.chainableOutputs.addAll(chainableOutputs);
+    }
+
+    public List<StreamEdge> getNonChainableOutputs() {
+        return nonChainableOutputs;
+    }
+
+    public void setNonChainableOutputs(List<StreamEdge> NonChainableOutEdges) {
+        this.nonChainableOutputs.addAll(NonChainableOutEdges);
+    }
+
+    public StreamConfig getVertexConfig() {
+        return vertexConfig;
+    }
+
+    public void setVertexConfig(StreamConfig vertexConfig) {
+        this.vertexConfig = vertexConfig;
+    }
+
+    public void addChainedConfig(Integer streamNodeId, StreamConfig streamConfig) {
+        chainedConfigs.put(streamNodeId, streamConfig);
+    }
+
+    public Map<Integer, StreamConfig> getChainedConfigs() {
+        return chainedConfigs;
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
