### PR TITLE
Skewed join part1 dev

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -71,11 +72,11 @@ public class InputGateDeploymentDescriptor implements Serializable {
     private final ResultPartitionType consumedPartitionType;
 
     /**
-     * Range of the index of the consumed subpartition of each consumed partition. This index
+     * Range of the index of the consumed subpartition of each consumed partition ranges. This index
      * depends on the {@link DistributionPattern} and the subtask indices of the producing and
      * consuming task. The range is inclusive.
      */
-    private final IndexRange consumedSubpartitionIndexRange;
+    private final Map<IndexRange, IndexRange> consumedSubpartitionGroups;
 
     /** An input channel for each consumed subpartition. */
     private transient ShuffleDescriptor[] inputChannels;
@@ -110,9 +111,25 @@ public class InputGateDeploymentDescriptor implements Serializable {
             IndexRange consumedSubpartitionIndexRange,
             int numberOfInputChannels,
             List<MaybeOffloaded<ShuffleDescriptorGroup>> serializedInputChannels) {
+        this(
+                consumedResultId,
+                consumedPartitionType,
+                Collections.singletonMap(
+                        new IndexRange(0, numberOfInputChannels - 1),
+                        consumedSubpartitionIndexRange),
+                numberOfInputChannels,
+                serializedInputChannels);
+    }
+
+    public InputGateDeploymentDescriptor(
+            IntermediateDataSetID consumedResultId,
+            ResultPartitionType consumedPartitionType,
+            Map<IndexRange, IndexRange> consumedSubpartitionGroups,
+            int numberOfInputChannels,
+            List<MaybeOffloaded<ShuffleDescriptorGroup>> serializedInputChannels) {
         this.consumedResultId = checkNotNull(consumedResultId);
         this.consumedPartitionType = checkNotNull(consumedPartitionType);
-        this.consumedSubpartitionIndexRange = checkNotNull(consumedSubpartitionIndexRange);
+        this.consumedSubpartitionGroups = checkNotNull(consumedSubpartitionGroups);
         this.serializedInputChannels = checkNotNull(serializedInputChannels);
         this.numberOfInputChannels = numberOfInputChannels;
     }
@@ -132,15 +149,18 @@ public class InputGateDeploymentDescriptor implements Serializable {
 
     @Nonnegative
     public int getConsumedSubpartitionIndex() {
+        checkState(consumedSubpartitionGroups.size() == 1);
+        IndexRange consumedSubpartitionIndexRange =
+                consumedSubpartitionGroups.values().iterator().next();
         checkState(
                 consumedSubpartitionIndexRange.getStartIndex()
                         == consumedSubpartitionIndexRange.getEndIndex());
         return consumedSubpartitionIndexRange.getStartIndex();
     }
 
-    /** Return the index range of the consumed subpartitions. */
-    public IndexRange getConsumedSubpartitionIndexRange() {
-        return consumedSubpartitionIndexRange;
+    /** Return the consumed subpartition groups by input channel range. */
+    public Map<IndexRange, IndexRange> getConsumedSubpartitionGroups() {
+        return consumedSubpartitionGroups;
     }
 
     public ShuffleDescriptor[] getShuffleDescriptors() {
@@ -248,7 +268,7 @@ public class InputGateDeploymentDescriptor implements Serializable {
     public String toString() {
         return String.format(
                 "InputGateDeploymentDescriptor [result id: %s, "
-                        + "consumed subpartition index range: %s]",
-                consumedResultId.toString(), consumedSubpartitionIndexRange);
+                        + "consumed subpartition index range by input channel index range: %s]",
+                consumedResultId.toString(), consumedSubpartitionGroups);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
@@ -72,8 +72,8 @@ public class InputGateDeploymentDescriptor implements Serializable {
     private final ResultPartitionType consumedPartitionType;
 
     /**
-     * Range of the index of the consumed subpartition of each consumed partition ranges. This index
-     * depends on the {@link DistributionPattern} and the subtask indices of the producing and
+     * Range of the index of the consumed subpartition of each input channel index ranges. This
+     * index depends on the {@link DistributionPattern} and the subtask indices of the producing and
      * consuming task. The range is inclusive.
      */
     private final Map<IndexRange, IndexRange> consumedSubpartitionGroups;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputInfo.java
@@ -34,8 +34,8 @@ public class ExecutionVertexInputInfo implements Serializable {
 
     private final int subtaskIndex;
 
-    // The keys of this Map are ordered, and there is no overlap between the IndexRange of the keys.
-    private final Map<IndexRange, IndexRange> consumedSubpartitionGroupsInOrder;
+    // The key is the partition index range, and the value is the subpartition index range.
+    private final Map<IndexRange, IndexRange> consumedSubpartitionGroups;
 
     public ExecutionVertexInputInfo(
             final int subtaskIndex,
@@ -48,15 +48,14 @@ public class ExecutionVertexInputInfo implements Serializable {
     }
 
     public ExecutionVertexInputInfo(
-            final int subtaskIndex,
-            final Map<IndexRange, IndexRange> consumedSubpartitionGroupsInOrder) {
+            final int subtaskIndex, final Map<IndexRange, IndexRange> consumedSubpartitionGroups) {
         this.subtaskIndex = subtaskIndex;
-        this.consumedSubpartitionGroupsInOrder = checkNotNull(consumedSubpartitionGroupsInOrder);
+        this.consumedSubpartitionGroups = checkNotNull(consumedSubpartitionGroups);
     }
 
     /** Get the subpartition groups this subtask should consume. */
-    public Map<IndexRange, IndexRange> getConsumedSubpartitionGroupsInOrder() {
-        return consumedSubpartitionGroupsInOrder;
+    public Map<IndexRange, IndexRange> getConsumedSubpartitionGroups() {
+        return consumedSubpartitionGroups;
     }
 
     /** Get the index of this subtask. */
@@ -71,8 +70,7 @@ public class ExecutionVertexInputInfo implements Serializable {
         } else if (obj != null && obj.getClass() == getClass()) {
             ExecutionVertexInputInfo that = (ExecutionVertexInputInfo) obj;
             return that.subtaskIndex == this.subtaskIndex
-                    && that.consumedSubpartitionGroupsInOrder.equals(
-                            this.consumedSubpartitionGroupsInOrder);
+                    && that.consumedSubpartitionGroups.equals(this.consumedSubpartitionGroups);
         } else {
             return false;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputInfo.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.executiongraph;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -32,27 +34,29 @@ public class ExecutionVertexInputInfo implements Serializable {
 
     private final int subtaskIndex;
 
-    private final IndexRange partitionIndexRange;
-
-    private final IndexRange subpartitionIndexRange;
+    // The keys of this Map are ordered, and there is no overlap between the IndexRange of the keys.
+    private final Map<IndexRange, IndexRange> consumedSubpartitionGroupsInOrder;
 
     public ExecutionVertexInputInfo(
             final int subtaskIndex,
             final IndexRange partitionIndexRange,
             final IndexRange subpartitionIndexRange) {
+        this(
+                subtaskIndex,
+                Collections.singletonMap(
+                        checkNotNull(partitionIndexRange), checkNotNull(subpartitionIndexRange)));
+    }
+
+    public ExecutionVertexInputInfo(
+            final int subtaskIndex,
+            final Map<IndexRange, IndexRange> consumedSubpartitionGroupsInOrder) {
         this.subtaskIndex = subtaskIndex;
-        this.partitionIndexRange = checkNotNull(partitionIndexRange);
-        this.subpartitionIndexRange = checkNotNull(subpartitionIndexRange);
+        this.consumedSubpartitionGroupsInOrder = checkNotNull(consumedSubpartitionGroupsInOrder);
     }
 
-    /** Get the subpartition range this subtask should consume. */
-    public IndexRange getSubpartitionIndexRange() {
-        return subpartitionIndexRange;
-    }
-
-    /** Get the partition range this subtask should consume. */
-    public IndexRange getPartitionIndexRange() {
-        return partitionIndexRange;
+    /** Get the subpartition groups this subtask should consume. */
+    public Map<IndexRange, IndexRange> getConsumedSubpartitionGroupsInOrder() {
+        return consumedSubpartitionGroupsInOrder;
     }
 
     /** Get the index of this subtask. */
@@ -67,8 +71,8 @@ public class ExecutionVertexInputInfo implements Serializable {
         } else if (obj != null && obj.getClass() == getClass()) {
             ExecutionVertexInputInfo that = (ExecutionVertexInputInfo) obj;
             return that.subtaskIndex == this.subtaskIndex
-                    && that.partitionIndexRange.equals(this.partitionIndexRange)
-                    && that.subpartitionIndexRange.equals(this.subpartitionIndexRange);
+                    && that.consumedSubpartitionGroupsInOrder.equals(
+                            this.consumedSubpartitionGroupsInOrder);
         } else {
             return false;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/FullyFilledBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/FullyFilledBuffer.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegment;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
+import org.apache.flink.shaded.netty4.io.netty.buffer.CompositeByteBuf;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An implementation of {@link Buffer} represents a fully filled buffer which contains multiple
+ * partial buffers for network data communication.
+ *
+ * <p>All sub-buffers must share the same header information, such as data type, compression status,
+ * and other metadata.
+ */
+public class FullyFilledBuffer implements Buffer {
+
+    private final DataType dataType;
+
+    private final int length;
+
+    private final boolean isCompressed;
+
+    private final List<Buffer> partialBuffers = new ArrayList<>();
+
+    private int currentLength;
+
+    private ByteBufAllocator allocator;
+
+    public FullyFilledBuffer(DataType dataType, int length, boolean isCompressed) {
+        this.dataType = checkNotNull(dataType);
+        this.length = length;
+        this.isCompressed = isCompressed;
+    }
+
+    @Override
+    public boolean isBuffer() {
+        return dataType.isBuffer();
+    }
+
+    @Override
+    public void recycleBuffer() {
+        for (Buffer partialBuffer : partialBuffers) {
+            partialBuffer.recycleBuffer();
+        }
+    }
+
+    @Override
+    public Buffer retainBuffer() {
+        for (Buffer partialBuffer : partialBuffers) {
+            partialBuffer.retainBuffer();
+        }
+        return this;
+    }
+
+    @Override
+    public int getSize() {
+        return currentLength;
+    }
+
+    @Override
+    public int readableBytes() {
+        return currentLength;
+    }
+
+    @Override
+    public void setAllocator(ByteBufAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    @Override
+    public ByteBuf asByteBuf() {
+        CompositeByteBuf compositeByteBuf = checkNotNull(allocator).compositeDirectBuffer();
+        for (Buffer buffer : partialBuffers) {
+            if (buffer instanceof CompositeBuffer) {
+                buffer.setAllocator(allocator);
+            }
+            compositeByteBuf.addComponent(buffer.asByteBuf());
+        }
+        compositeByteBuf.writerIndex(currentLength);
+        return compositeByteBuf;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return isCompressed;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    public void addPartialBuffer(Buffer buffer) {
+        checkState(
+                buffer.getDataType() == dataType,
+                "Partial buffer data type must be the same as the fully filled buffer.");
+        checkState(
+                buffer.isCompressed() == isCompressed,
+                "Partial buffer compression status must be the same as the fully filled buffer.");
+
+        partialBuffers.add(buffer);
+        currentLength += buffer.readableBytes();
+        checkState(currentLength <= length);
+    }
+
+    public List<Buffer> getPartialBuffers() {
+        return Collections.unmodifiableList(partialBuffers);
+    }
+
+    public int missingLength() {
+        return length - currentLength;
+    }
+
+    @Override
+    public MemorySegment getMemorySegment() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getMemorySegmentOffset() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BufferRecycler getRecycler() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRecycler(BufferRecycler bufferRecycler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRecycled() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Buffer readOnlySlice() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Buffer readOnlySlice(int index, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getMaxCapacity() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getReaderIndex() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setReaderIndex(int readerIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSize(int writerIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuffer getNioBufferReadable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuffer getNioBuffer(int index, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCompressed(boolean isCompressed) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDataType(DataType dataType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int refCnt() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/BufferResponseDecoder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/BufferResponseDecoder.java
@@ -23,9 +23,13 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse.MESSAGE_HEADER_LENGTH;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** The decoder for {@link BufferResponse}. */
 class BufferResponseDecoder extends NettyMessageDecoder {
@@ -35,6 +39,16 @@ class BufferResponseDecoder extends NettyMessageDecoder {
 
     /** The accumulation buffer of message header. */
     private ByteBuf messageHeaderBuffer;
+
+    /**
+     * Accumulates bytes for a partial buffer size.
+     *
+     * <p>In scenarios such as Sort-merge shuffle, where small buffers are merged, each small buffer
+     * size is written sequentially in the data stream. This list temporarily holds the bytes needed
+     * to form a full integer representation of a buffer's size when there aren't sufficient bytes
+     * to read an integer directly from the incoming data buffer.
+     */
+    private List<Byte> partialSizeBytes;
 
     /**
      * The BufferResponse message that has its message header decoded, but still not received all
@@ -62,6 +76,9 @@ class BufferResponseDecoder extends NettyMessageDecoder {
 
         if (bufferResponse != null) {
             int remainingBufferSize = bufferResponse.bufferSize - decodedDataBufferSize;
+
+            decodePartialBufferSizes(data);
+
             int actualBytesToDecode = Math.min(data.readableBytes(), remainingBufferSize);
 
             // For the case of data buffer really exists in BufferResponse now.
@@ -85,6 +102,81 @@ class BufferResponseDecoder extends NettyMessageDecoder {
         }
 
         return DecodingResult.NOT_FINISHED;
+    }
+
+    /**
+     * Decodes the sizes of partial buffers from the provided ByteBuf. This function processes the
+     * incoming data and accumulates bytes until a full integer can be formed to represent the size
+     * of each buffer.
+     *
+     * @param data the ByteBuf containing the incoming data.
+     */
+    private void decodePartialBufferSizes(ByteBuf data) {
+        // If partial buffers are present and not all are processed yet
+        if (bufferResponse.numOfPartialBuffers > 0
+                && bufferResponse.getPartialBufferSizes().size()
+                        < bufferResponse.numOfPartialBuffers) {
+
+            // Continue completing the current partial buffer size if necessary
+            accumulatePartialSizeBytes(data);
+
+            // Process remaining partial buffer sizes when possible
+            readRemainingBufferSizes(data);
+        }
+    }
+
+    /**
+     * Accumulates bytes to form a complete integer size for a partial buffer. If enough bytes are
+     * accumulated, forms an integer and adds it to bufferResponse list.
+     *
+     * @param data the ByteBuf containing the incoming data.
+     */
+    private void accumulatePartialSizeBytes(ByteBuf data) {
+        if (partialSizeBytes != null) {
+            while (partialSizeBytes.size() < Integer.BYTES && data.isReadable()) {
+                partialSizeBytes.add(data.readByte());
+            }
+            if (partialSizeBytes.size() == Integer.BYTES) {
+                int size = buildIntFromBytes(partialSizeBytes);
+                bufferResponse.getPartialBufferSizes().add(size);
+                partialSizeBytes = null;
+            }
+        }
+    }
+
+    /**
+     * Reads remaining complete partial buffer sizes directly from the ByteBuf if possible. Prepares
+     * for partially available sizes by initializing byte accumulator.
+     *
+     * @param data the ByteBuf containing the incoming data.
+     */
+    private void readRemainingBufferSizes(ByteBuf data) {
+        while (data.isReadable()
+                && bufferResponse.getPartialBufferSizes().size()
+                        < bufferResponse.numOfPartialBuffers) {
+            if (data.readableBytes() >= Integer.BYTES) {
+                bufferResponse.getPartialBufferSizes().add(data.readInt());
+            } else {
+                partialSizeBytes = new ArrayList<>();
+                while (data.isReadable()) {
+                    partialSizeBytes.add(data.readByte());
+                }
+            }
+        }
+    }
+
+    /**
+     * Converts a list of four bytes into an integer.
+     *
+     * @param byteList the list containing four bytes.
+     * @return the constructed integer.
+     */
+    private int buildIntFromBytes(List<Byte> byteList) {
+        checkState(byteList.size() == Integer.BYTES);
+        return ((byteList.get(0) & 0xFF) << 24)
+                | ((byteList.get(1) & 0xFF) << 16)
+                | ((byteList.get(2) & 0xFF) << 8)
+                | (byteList.get(3) & 0xFF);
     }
 
     private void decodeMessageHeader(ByteBuf data) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
@@ -19,8 +19,12 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.NetworkClientHandler;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.netty.exception.LocalTransportException;
 import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
 import org.apache.flink.runtime.io.network.netty.exception.TransportException;
@@ -39,9 +43,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -358,15 +364,73 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
         if (bufferOrEvent.isBuffer() && bufferOrEvent.bufferSize == 0) {
             inputChannel.onEmptyBuffer(bufferOrEvent.sequenceNumber, bufferOrEvent.backlog);
         } else if (bufferOrEvent.getBuffer() != null) {
-            inputChannel.onBuffer(
-                    bufferOrEvent.getBuffer(),
-                    bufferOrEvent.sequenceNumber,
-                    bufferOrEvent.backlog,
-                    bufferOrEvent.subpartitionId);
+            if (bufferOrEvent.numOfPartialBuffers > 0) {
+                int offset = 0;
+
+                int seq = bufferOrEvent.sequenceNumber;
+                AtomicInteger waitToBeReleased =
+                        new AtomicInteger(bufferOrEvent.numOfPartialBuffers);
+                AtomicInteger processedPartialBuffers = new AtomicInteger(0);
+                try {
+                    for (int i = 0; i < bufferOrEvent.numOfPartialBuffers; i++) {
+                        int size = bufferOrEvent.getPartialBufferSizes().get(i);
+
+                        processedPartialBuffers.incrementAndGet();
+                        inputChannel.onBuffer(
+                                sliceBuffer(
+                                        bufferOrEvent,
+                                        memorySegment -> {
+                                            if (waitToBeReleased.decrementAndGet() == 0) {
+                                                bufferOrEvent.getBuffer().recycleBuffer();
+                                            }
+                                        },
+                                        offset,
+                                        size),
+                                seq++,
+                                i == bufferOrEvent.numOfPartialBuffers - 1
+                                        ? bufferOrEvent.backlog
+                                        : -1,
+                                bufferOrEvent.subpartitionId);
+                        offset += size;
+                    }
+                } catch (Throwable throwable) {
+                    LOG.error("Failed to process partial buffers.", throwable);
+                    if (processedPartialBuffers.get() != bufferOrEvent.numOfPartialBuffers) {
+                        bufferOrEvent.getBuffer().recycleBuffer();
+                    }
+                    throw throwable;
+                }
+            } else {
+                inputChannel.onBuffer(
+                        bufferOrEvent.getBuffer(),
+                        bufferOrEvent.sequenceNumber,
+                        bufferOrEvent.backlog,
+                        bufferOrEvent.subpartitionId);
+            }
+
         } else {
             throw new IllegalStateException(
                     "The read buffer is null in credit-based input channel.");
         }
+    }
+
+    private static NetworkBuffer sliceBuffer(
+            NettyMessage.BufferResponse bufferOrEvent,
+            BufferRecycler recycler,
+            int offset,
+            int size) {
+        ByteBuffer nioBuffer = bufferOrEvent.getBuffer().getNioBuffer(offset, size);
+
+        MemorySegment segment;
+        if (nioBuffer.isDirect()) {
+            segment = MemorySegmentFactory.wrapOffHeapMemory(nioBuffer);
+        } else {
+            byte[] bytes = nioBuffer.array();
+            segment = MemorySegmentFactory.wrap(bytes);
+        }
+
+        return new NetworkBuffer(
+                segment, recycler, bufferOrEvent.dataType, bufferOrEvent.isCompressed, size);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
@@ -50,6 +51,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.ProtocolException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -266,10 +269,11 @@ public abstract class NettyMessage {
 
         static final byte ID = 0;
 
-        // receiver ID (16), sequence number (4), backlog (4), dataType (1), isCompressed (1),
-        // buffer size (4)
+        // receiver ID (16), sequence number (4), backlog (4), subpartition id (4), partial buffers
+        // number (4), dataType (1), isCompressed (1), buffer size (4)
         static final int MESSAGE_HEADER_LENGTH =
                 InputChannelID.getByteBufLength()
+                        + Integer.BYTES
                         + Integer.BYTES
                         + Integer.BYTES
                         + Integer.BYTES
@@ -293,6 +297,10 @@ public abstract class NettyMessage {
 
         final int bufferSize;
 
+        final int numOfPartialBuffers;
+
+        private List<Integer> partialBufferSizes = new ArrayList<>();
+
         private BufferResponse(
                 @Nullable Buffer buffer,
                 Buffer.DataType dataType,
@@ -300,6 +308,7 @@ public abstract class NettyMessage {
                 int sequenceNumber,
                 InputChannelID receiverId,
                 int subpartitionId,
+                int numOfPartialBuffers,
                 int backlog,
                 int bufferSize) {
             this.buffer = buffer;
@@ -310,6 +319,7 @@ public abstract class NettyMessage {
             this.subpartitionId = subpartitionId;
             this.backlog = backlog;
             this.bufferSize = bufferSize;
+            this.numOfPartialBuffers = numOfPartialBuffers;
         }
 
         BufferResponse(
@@ -317,6 +327,7 @@ public abstract class NettyMessage {
                 int sequenceNumber,
                 InputChannelID receiverId,
                 int subpartitionId,
+                int numOfPartialBuffers,
                 int backlog) {
             this.buffer = checkNotNull(buffer);
             checkArgument(
@@ -330,6 +341,7 @@ public abstract class NettyMessage {
             this.subpartitionId = subpartitionId;
             this.backlog = backlog;
             this.bufferSize = buffer.getSize();
+            this.numOfPartialBuffers = numOfPartialBuffers;
         }
 
         boolean isBuffer() {
@@ -345,6 +357,10 @@ public abstract class NettyMessage {
             if (buffer != null) {
                 buffer.recycleBuffer();
             }
+        }
+
+        public List<Integer> getPartialBufferSizes() {
+            return partialBufferSizes;
         }
 
         // --------------------------------------------------------------------
@@ -396,15 +412,26 @@ public abstract class NettyMessage {
         private ByteBuf fillHeader(ByteBufAllocator allocator) {
             // only allocate header buffer - we will combine it with the data buffer below
             ByteBuf headerBuf =
-                    allocateBuffer(allocator, ID, MESSAGE_HEADER_LENGTH, bufferSize, false);
+                    allocateBuffer(
+                            allocator,
+                            ID,
+                            MESSAGE_HEADER_LENGTH + Integer.BYTES * numOfPartialBuffers,
+                            bufferSize,
+                            false);
 
             receiverId.writeTo(headerBuf);
             headerBuf.writeInt(subpartitionId);
+            headerBuf.writeInt(numOfPartialBuffers);
             headerBuf.writeInt(sequenceNumber);
             headerBuf.writeInt(backlog);
             headerBuf.writeByte(dataType.ordinal());
             headerBuf.writeBoolean(isCompressed);
             headerBuf.writeInt(buffer.readableBytes());
+            for (int i = 0; i < numOfPartialBuffers; i++) {
+                int bytes = ((FullyFilledBuffer) buffer).getPartialBuffers().get(i).readableBytes();
+                headerBuf.writeInt(bytes);
+            }
+
             return headerBuf;
         }
 
@@ -422,6 +449,7 @@ public abstract class NettyMessage {
                 ByteBuf messageHeader, NetworkBufferAllocator bufferAllocator) {
             InputChannelID receiverId = InputChannelID.fromByteBuf(messageHeader);
             int subpartitionId = messageHeader.readInt();
+            int numOfPartialBuffers = messageHeader.readInt();
             int sequenceNumber = messageHeader.readInt();
             int backlog = messageHeader.readInt();
             Buffer.DataType dataType = Buffer.DataType.values()[messageHeader.readByte()];
@@ -456,6 +484,7 @@ public abstract class NettyMessage {
                     sequenceNumber,
                     receiverId,
                     subpartitionId,
+                    numOfPartialBuffers,
                     backlog,
                     size);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.NetworkSequenceViewReader;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.PartitionRequestListener;
@@ -340,6 +341,11 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
                                     next.getSequenceNumber(),
                                     reader.getReceiverId(),
                                     nextSubpartitionId,
+                                    next.buffer() instanceof FullyFilledBuffer
+                                            ? ((FullyFilledBuffer) next.buffer())
+                                                    .getPartialBuffers()
+                                                    .size()
+                                            : 0,
                                     next.buffersInBacklog());
 
                     // Write and flush and wait until this is done before

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -40,6 +40,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -536,8 +537,15 @@ public class SortMergeResultPartition extends ResultPartition {
     protected ResultSubpartitionView createSubpartitionView(
             int subpartitionIndex, BufferAvailabilityListener availabilityListener)
             throws IOException {
+        throw new UnsupportedEncodingException();
+    }
+
+    @Override
+    public ResultSubpartitionView createSubpartitionView(
+            ResultSubpartitionIndexSet indexSet, BufferAvailabilityListener availabilityListener)
+            throws IOException {
         synchronized (lock) {
-            checkElementIndex(subpartitionIndex, numSubpartitions, "Subpartition not found.");
+            checkElementIndex(indexSet.getEndIndex(), numSubpartitions, "Subpartition not found.");
             checkState(!isReleased(), "Partition released.");
             checkState(isFinished(), "Trying to read unfinished blocking partition.");
 
@@ -546,7 +554,7 @@ public class SortMergeResultPartition extends ResultPartition {
             }
 
             return readScheduler.createSubpartitionReader(
-                    availabilityListener, subpartitionIndex, resultFile);
+                    availabilityListener, indexSet, resultFile);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -341,15 +341,15 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
 
     SortMergeSubpartitionReader createSubpartitionReader(
             BufferAvailabilityListener availabilityListener,
-            int targetSubpartition,
+            ResultSubpartitionIndexSet indexSet,
             PartitionedFile resultFile)
             throws IOException {
         synchronized (lock) {
             checkState(!isReleased, "Partition is already released.");
-
-            PartitionedFileReader fileReader = createFileReader(resultFile, targetSubpartition);
+            PartitionedFileReader fileReader = createFileReader(resultFile, indexSet);
             SortMergeSubpartitionReader subpartitionReader =
-                    new SortMergeSubpartitionReader(availabilityListener, fileReader);
+                    new SortMergeSubpartitionReader(
+                            bufferPool.getBufferSize(), availabilityListener, fileReader);
             if (allReaders.isEmpty()) {
                 bufferPool.registerRequester(this);
             }
@@ -374,7 +374,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
 
     @GuardedBy("lock")
     private PartitionedFileReader createFileReader(
-            PartitionedFile resultFile, int targetSubpartition) throws IOException {
+            PartitionedFile resultFile, ResultSubpartitionIndexSet indexSet) throws IOException {
         assert Thread.holdsLock(lock);
 
         try {
@@ -384,7 +384,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             PartitionedFileReader partitionedFileReader =
                     new PartitionedFileReader(
                             resultFile,
-                            targetSubpartition,
+                            indexSet,
                             dataFileChannel,
                             indexFileChannel,
                             headerBuf,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 
 import javax.annotation.Nullable;
@@ -35,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Subpartition data reader for {@link SortMergeResultPartition}. */
 class SortMergeSubpartitionReader
@@ -70,10 +72,18 @@ class SortMergeSubpartitionReader
     /** Sequence number of the next buffer to be sent to the consumer. */
     private int sequenceNumber;
 
+    @GuardedBy("lock")
+    private final Queue<FullyFilledBuffer> fullyFilledBuffersToRead = new ArrayDeque<>();
+
+    private FullyFilledBuffer toFilledBuffer;
+
+    private final int pageSize;
+
     SortMergeSubpartitionReader(
-            BufferAvailabilityListener listener, PartitionedFileReader fileReader) {
+            int pageSize, BufferAvailabilityListener listener, PartitionedFileReader fileReader) {
         this.availabilityListener = checkNotNull(listener);
         this.fileReader = checkNotNull(fileReader);
+        this.pageSize = pageSize;
     }
 
     @Nullable
@@ -90,28 +100,29 @@ class SortMergeSubpartitionReader
             }
 
             Buffer lookAhead = buffersRead.peek();
-            return BufferAndBacklog.fromBufferAndLookahead(
-                    buffer,
-                    lookAhead == null ? Buffer.DataType.NONE : lookAhead.getDataType(),
-                    dataBufferBacklog,
-                    sequenceNumber++);
+            BufferAndBacklog bufferAndBacklog =
+                    BufferAndBacklog.fromBufferAndLookahead(
+                            buffer,
+                            lookAhead == null ? Buffer.DataType.NONE : lookAhead.getDataType(),
+                            dataBufferBacklog,
+                            sequenceNumber);
+            if (buffer instanceof FullyFilledBuffer) {
+                sequenceNumber += ((FullyFilledBuffer) buffer).getPartialBuffers().size();
+            } else {
+                sequenceNumber++;
+            }
+            return bufferAndBacklog;
         }
     }
 
     private void addBuffer(Buffer buffer) {
-        boolean notifyAvailable = false;
         boolean needRecycleBuffer = false;
 
         synchronized (lock) {
             if (isReleased) {
                 needRecycleBuffer = true;
             } else {
-                notifyAvailable = buffersRead.isEmpty();
-
-                buffersRead.add(buffer);
-                if (buffer.isBuffer()) {
-                    ++dataBufferBacklog;
-                }
+                addBufferToFullyFilledBuffer(buffer);
             }
         }
 
@@ -119,15 +130,55 @@ class SortMergeSubpartitionReader
             buffer.recycleBuffer();
             throw new IllegalStateException("Subpartition reader has been already released.");
         }
+    }
 
-        if (notifyAvailable) {
-            notifyDataAvailable();
+    private void addBufferToFullyFilledBuffer(Buffer buffer) {
+        if (toFilledBuffer == null) {
+            toFilledBuffer =
+                    new FullyFilledBuffer(buffer.getDataType(), pageSize, buffer.isCompressed());
+            fullyFilledBuffersToRead.add(toFilledBuffer);
+            if (buffer.isBuffer()) {
+                ++dataBufferBacklog;
+            }
         }
+
+        if (toFilledBuffer.missingLength() < buffer.getSize()
+                || toFilledBuffer.getDataType() != buffer.getDataType()
+                || toFilledBuffer.isCompressed() != buffer.isCompressed()) {
+            checkState(!toFilledBuffer.getPartialBuffers().isEmpty());
+
+            toFilledBuffer =
+                    new FullyFilledBuffer(buffer.getDataType(), pageSize, buffer.isCompressed());
+            fullyFilledBuffersToRead.add(toFilledBuffer);
+            if (buffer.isBuffer()) {
+                ++dataBufferBacklog;
+            }
+        }
+
+        toFilledBuffer.addPartialBuffer(buffer);
     }
 
     /** This method is called by the IO thread of {@link SortMergeResultPartitionReadScheduler}. */
     boolean readBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler) throws IOException {
-        return fileReader.readCurrentRegion(buffers, recycler, this::addBuffer);
+        boolean hasRemaining = fileReader.readCurrentRegion(buffers, recycler, this::addBuffer);
+
+        boolean canNotify;
+        synchronized (lock) {
+            boolean emptyBefore = buffersRead.isEmpty();
+            buffersRead.addAll(fullyFilledBuffersToRead);
+            fullyFilledBuffersToRead.clear();
+            toFilledBuffer = null;
+
+            boolean notEmptyAfter = !buffersRead.isEmpty();
+            canNotify = notEmptyAfter && emptyBefore;
+        }
+
+        // can not be locked!
+        if (canNotify) {
+            notifyDataAvailable();
+        }
+
+        return hasRemaining;
     }
 
     CompletableFuture<?> getReleaseFuture() {
@@ -181,6 +232,9 @@ class SortMergeSubpartitionReader
             if (failureCause == null) {
                 failureCause = throwable;
             }
+            buffersRead.addAll(fullyFilledBuffersToRead);
+            fullyFilledBuffersToRead.clear();
+            toFilledBuffer = null;
             buffersToRecycle = new ArrayList<>(buffersRead);
             buffersRead.clear();
             dataBufferBacklog = 0;
@@ -250,6 +304,7 @@ class SortMergeSubpartitionReader
 
     @Override
     public int peekNextBufferSubpartitionId() {
-        throw new UnsupportedOperationException();
+        // because sort merge shuffle does not care about subpartition id, so just return -1
+        return -1;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
 import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
@@ -44,7 +45,10 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -73,6 +77,8 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     private volatile boolean isReleased;
 
     private final ChannelStatePersister channelStatePersister;
+
+    private final Deque<BufferAndBacklog> toBeConsumedBuffers = new ArrayDeque<>();
 
     public LocalInputChannel(
             SingleInputGate inputGate,
@@ -116,6 +122,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
     @Override
     protected void requestSubpartitions() throws IOException {
+        checkState(toBeConsumedBuffers.isEmpty());
 
         boolean retriggerRequest = false;
         boolean notifyDataAvailable = false;
@@ -226,6 +233,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
+        if (!toBeConsumedBuffers.isEmpty()) {
+            return getBufferAndAvailability(toBeConsumedBuffers.removeFirst());
+        }
+
         ResultSubpartitionView subpartitionView = this.subpartitionView;
         if (subpartitionView == null) {
             // There is a possible race condition between writing a EndOfPartitionEvent (1) and
@@ -267,6 +278,27 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
         Buffer buffer = next.buffer();
 
+        if (buffer instanceof FullyFilledBuffer) {
+            List<Buffer> partialBuffers = ((FullyFilledBuffer) buffer).getPartialBuffers();
+            int seq = next.getSequenceNumber();
+            for (Buffer partialBuffer : partialBuffers) {
+                toBeConsumedBuffers.add(
+                        new BufferAndBacklog(
+                                partialBuffer,
+                                next.buffersInBacklog(),
+                                buffer.getDataType(),
+                                seq++));
+            }
+
+            return getBufferAndAvailability(toBeConsumedBuffers.removeFirst());
+        }
+
+        return getBufferAndAvailability(next);
+    }
+
+    private Optional<BufferAndAvailability> getBufferAndAvailability(BufferAndBacklog next)
+            throws IOException {
+        Buffer buffer = next.buffer();
         if (buffer instanceof FileRegionBuffer) {
             buffer = ((FileRegionBuffer) buffer).readInto(inputGate.getUnpooledSegment());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -53,7 +53,6 @@ import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.throughput.BufferDebloater;
 import org.apache.flink.runtime.throughput.ThroughputCalculator;
-import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.function.SupplierWithException;
 
@@ -152,11 +151,6 @@ public class SingleInputGateFactory {
         // This variable describes whether it is supported to have one input channel consume
         // multiple subpartitions, if multiple subpartitions from the same partition are
         // assigned to this input gate.
-        //
-        // For now this function is only supported in the new mode of Hybrid Shuffle.
-        boolean isSharedInputChannelSupported =
-                igdd.getConsumedPartitionType().isHybridResultPartition()
-                        && tieredStorageConfiguration != null;
 
         GateBuffersSpec gateBuffersSpec =
                 createGateBuffersSpec(
@@ -164,10 +158,7 @@ public class SingleInputGateFactory {
                         configuredNetworkBuffersPerChannel,
                         floatingNetworkBuffersPerGate,
                         igdd.getConsumedPartitionType(),
-                        calculateNumChannels(
-                                igdd.getShuffleDescriptors().length,
-                                igdd.getConsumedSubpartitionIndexRange().size(),
-                                isSharedInputChannelSupported),
+                        igdd.getShuffleDescriptors().length,
                         tieredStorageConfiguration != null);
         SupplierWithException<BufferPool, IOException> bufferPoolFactory =
                 createBufferPoolFactory(
@@ -192,10 +183,7 @@ public class SingleInputGateFactory {
                         gateIndex,
                         igdd.getConsumedResultId(),
                         igdd.getConsumedPartitionType(),
-                        calculateNumChannels(
-                                igdd.getShuffleDescriptors().length,
-                                subpartitionIndexSet.size(),
-                                isSharedInputChannelSupported),
+                        igdd.getShuffleDescriptors().length,
                         partitionProducerStateProvider,
                         bufferPoolFactory,
                         bufferDecompressor,
@@ -206,13 +194,7 @@ public class SingleInputGateFactory {
                                 owningTaskName, gateIndex, networkInputGroup.addGroup(gateIndex)));
 
         createInputChannelsAndTieredStorageService(
-                owningTaskName,
-                igdd,
-                inputGate,
-                subpartitionIndexSet,
-                gateBuffersSpec,
-                metrics,
-                isSharedInputChannelSupported);
+                owningTaskName, igdd, inputGate, subpartitionIndexSet, gateBuffersSpec, metrics);
         return inputGate;
     }
 
@@ -245,18 +227,12 @@ public class SingleInputGateFactory {
             SingleInputGate inputGate,
             ResultSubpartitionIndexSet subpartitionIndexSet,
             GateBuffersSpec gateBuffersSpec,
-            InputChannelMetrics metrics,
-            boolean isSharedInputChannelSupported) {
+            InputChannelMetrics metrics) {
         ShuffleDescriptor[] shuffleDescriptors =
                 inputGateDeploymentDescriptor.getShuffleDescriptors();
 
         // Create the input channels. There is one input channel for each consumed subpartition.
-        InputChannel[] inputChannels =
-                new InputChannel
-                        [calculateNumChannels(
-                                shuffleDescriptors.length,
-                                subpartitionIndexSet.size(),
-                                isSharedInputChannelSupported)];
+        InputChannel[] inputChannels = new InputChannel[shuffleDescriptors.length];
 
         ChannelStatistics channelStatistics = new ChannelStatistics();
 
@@ -266,51 +242,26 @@ public class SingleInputGateFactory {
         for (ShuffleDescriptor descriptor : shuffleDescriptors) {
             TieredStoragePartitionId partitionId =
                     TieredStorageIdMappingUtils.convertId(descriptor.getResultPartitionID());
-            if (isSharedInputChannelSupported) {
-                inputChannels[channelIdx] =
-                        createInputChannel(
-                                inputGate,
-                                channelIdx,
-                                gateBuffersSpec.getEffectiveExclusiveBuffersPerChannel(),
-                                descriptor,
-                                subpartitionIndexSet,
-                                channelStatistics,
-                                metrics);
-                if (tieredStorageConfiguration != null) {
-                    addTierShuffleDescriptors(tierShuffleDescriptors, descriptor);
+            inputChannels[channelIdx] =
+                    createInputChannel(
+                            inputGate,
+                            channelIdx,
+                            gateBuffersSpec.getEffectiveExclusiveBuffersPerChannel(),
+                            descriptor,
+                            subpartitionIndexSet,
+                            channelStatistics,
+                            metrics);
+            if (tieredStorageConfiguration != null) {
+                addTierShuffleDescriptors(tierShuffleDescriptors, descriptor);
 
-                    tieredStorageConsumerSpecs.add(
-                            new TieredStorageConsumerSpec(
-                                    inputGate.getInputGateIndex(),
-                                    partitionId,
-                                    new TieredStorageInputChannelId(channelIdx),
-                                    subpartitionIndexSet));
-                }
-                channelIdx++;
-            } else {
-                for (int subpartitionIndex : subpartitionIndexSet.values()) {
-                    inputChannels[channelIdx] =
-                            createInputChannel(
-                                    inputGate,
-                                    channelIdx,
-                                    gateBuffersSpec.getEffectiveExclusiveBuffersPerChannel(),
-                                    descriptor,
-                                    new ResultSubpartitionIndexSet(subpartitionIndex),
-                                    channelStatistics,
-                                    metrics);
-                    if (tieredStorageConfiguration != null) {
-                        addTierShuffleDescriptors(tierShuffleDescriptors, descriptor);
-
-                        tieredStorageConsumerSpecs.add(
-                                new TieredStorageConsumerSpec(
-                                        inputGate.getInputGateIndex(),
-                                        partitionId,
-                                        new TieredStorageInputChannelId(channelIdx),
-                                        new ResultSubpartitionIndexSet(subpartitionIndex)));
-                    }
-                    channelIdx++;
-                }
+                tieredStorageConsumerSpecs.add(
+                        new TieredStorageConsumerSpec(
+                                inputGate.getInputGateIndex(),
+                                partitionId,
+                                new TieredStorageInputChannelId(channelIdx),
+                                subpartitionIndexSet));
             }
+            channelIdx++;
         }
 
         inputGate.setInputChannels(inputChannels);
@@ -371,17 +322,6 @@ public class SingleInputGateFactory {
                                 subpartitionIndexSet,
                                 channelStatistics,
                                 metrics));
-    }
-
-    private static int calculateNumChannels(
-            int numShuffleDescriptors,
-            int numSubpartitions,
-            boolean isSharedInputChannelSupported) {
-        if (isSharedInputChannelSupported) {
-            return numShuffleDescriptors;
-        } else {
-            return MathUtils.checkedDownCast(((long) numShuffleDescriptors) * numSubpartitions);
-        }
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions.Compression
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.IndexRange;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
@@ -66,6 +67,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.runtime.io.network.partition.consumer.InputGateSpecUtils.createGateBuffersSpec;
@@ -175,8 +177,6 @@ public class SingleInputGateFactory {
         final String owningTaskName = owner.getOwnerName();
         final MetricGroup networkInputGroup = owner.getInputGroup();
 
-        ResultSubpartitionIndexSet subpartitionIndexSet =
-                new ResultSubpartitionIndexSet(igdd.getConsumedSubpartitionIndexRange());
         SingleInputGate inputGate =
                 new SingleInputGate(
                         owningTaskName,
@@ -194,7 +194,7 @@ public class SingleInputGateFactory {
                                 owningTaskName, gateIndex, networkInputGroup.addGroup(gateIndex)));
 
         createInputChannelsAndTieredStorageService(
-                owningTaskName, igdd, inputGate, subpartitionIndexSet, gateBuffersSpec, metrics);
+                owningTaskName, igdd, inputGate, gateBuffersSpec, metrics);
         return inputGate;
     }
 
@@ -225,11 +225,13 @@ public class SingleInputGateFactory {
             String owningTaskName,
             InputGateDeploymentDescriptor inputGateDeploymentDescriptor,
             SingleInputGate inputGate,
-            ResultSubpartitionIndexSet subpartitionIndexSet,
             GateBuffersSpec gateBuffersSpec,
             InputChannelMetrics metrics) {
         ShuffleDescriptor[] shuffleDescriptors =
                 inputGateDeploymentDescriptor.getShuffleDescriptors();
+
+        Map<IndexRange, IndexRange> consumedSubpartitionGroups =
+                inputGateDeploymentDescriptor.getConsumedSubpartitionGroups();
 
         // Create the input channels. There is one input channel for each consumed subpartition.
         InputChannel[] inputChannels = new InputChannel[shuffleDescriptors.length];
@@ -239,7 +241,10 @@ public class SingleInputGateFactory {
         int channelIdx = 0;
         final List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs = new ArrayList<>();
         List<List<TierShuffleDescriptor>> tierShuffleDescriptors = new ArrayList<>();
-        for (ShuffleDescriptor descriptor : shuffleDescriptors) {
+        for (int i = 0; i < shuffleDescriptors.length; i++) {
+            ShuffleDescriptor descriptor = shuffleDescriptors[i];
+            ResultSubpartitionIndexSet subpartitionIndexSet =
+                    getResultSubpartitionIndexSet(consumedSubpartitionGroups, i);
             TieredStoragePartitionId partitionId =
                     TieredStorageIdMappingUtils.convertId(descriptor.getResultPartitionID());
             inputChannels[channelIdx] =
@@ -322,6 +327,18 @@ public class SingleInputGateFactory {
                                 subpartitionIndexSet,
                                 channelStatistics,
                                 metrics));
+    }
+
+    private ResultSubpartitionIndexSet getResultSubpartitionIndexSet(
+            Map<IndexRange, IndexRange> consumedSubpartitionGroups, int index) {
+        for (Map.Entry<IndexRange, IndexRange> entry : consumedSubpartitionGroups.entrySet()) {
+            IndexRange partitionRange = entry.getKey();
+            if (index >= partitionRange.getStartIndex() && index <= partitionRange.getEndIndex()) {
+                return new ResultSubpartitionIndexSet(entry.getValue());
+            }
+        }
+        throw new IllegalStateException(
+                "SubpartitionIndexSet for channel " + index + " does not exist.");
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.executiongraph.IndexRange;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobEdge;
@@ -194,13 +195,11 @@ public class SsgNetworkMemoryCalculationUtils {
                 Map<IndexRange, IndexRange> consumedSubpartitionGroups =
                         vertex.getExecutionVertexInputInfo(
                                         resultPartition.getIntermediateResult().getId())
-                                .getConsumedSubpartitionGroupsInOrder();
+                                .getConsumedSubpartitionGroups();
 
-                int inputChannelNums = 0;
-                for (Map.Entry<IndexRange, IndexRange> entry :
-                        consumedSubpartitionGroups.entrySet()) {
-                    inputChannelNums += entry.getKey().size() * entry.getValue().size();
-                }
+                int inputChannelNums =
+                        SingleInputGateFactory.calculateInputChannelSize(
+                                consumedSubpartitionGroups);
 
                 maxInputChannelNums.merge(
                         partitionGroup.getIntermediateDataSetID(), inputChannelNums, Integer::max);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
@@ -198,7 +198,7 @@ public class SsgNetworkMemoryCalculationUtils {
                                 .getConsumedSubpartitionGroups();
 
                 int inputChannelNums =
-                        SingleInputGateFactory.calculateInputChannelSize(
+                        SingleInputGateFactory.calculateNumInputChannels(
                                 consumedSubpartitionGroups);
 
                 maxInputChannelNums.merge(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
@@ -190,15 +190,20 @@ public class SsgNetworkMemoryCalculationUtils {
 
                 IntermediateResultPartition resultPartition =
                         ejv.getGraph().getResultPartitionOrThrow((partitionGroup.getFirst()));
-                IndexRange subpartitionIndexRange =
+
+                Map<IndexRange, IndexRange> consumedSubpartitionGroups =
                         vertex.getExecutionVertexInputInfo(
                                         resultPartition.getIntermediateResult().getId())
-                                .getSubpartitionIndexRange();
+                                .getConsumedSubpartitionGroupsInOrder();
+
+                int inputChannelNums = 0;
+                for (Map.Entry<IndexRange, IndexRange> entry :
+                        consumedSubpartitionGroups.entrySet()) {
+                    inputChannelNums += entry.getKey().size() * entry.getValue().size();
+                }
 
                 maxInputChannelNums.merge(
-                        partitionGroup.getIntermediateDataSetID(),
-                        subpartitionIndexRange.size() * partitionGroup.size(),
-                        Integer::max);
+                        partitionGroup.getIntermediateDataSetID(), inputChannelNums, Integer::max);
                 inputPartitionTypes.putIfAbsent(
                         partitionGroup.getIntermediateDataSetID(),
                         partitionGroup.getResultPartitionType());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -749,13 +749,18 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
             for (IntermediateResult intermediateResult : intermediateResults) {
                 ExecutionVertexInputInfo inputInfo =
                         ev.getExecutionVertexInputInfo(intermediateResult.getId());
-                IndexRange partitionIndexRange = inputInfo.getPartitionIndexRange();
-                IndexRange subpartitionIndexRange = inputInfo.getSubpartitionIndexRange();
                 BlockingResultInfo blockingResultInfo =
                         checkNotNull(getBlockingResultInfo(intermediateResult.getId()));
-                inputBytes +=
-                        blockingResultInfo.getNumBytesProduced(
-                                partitionIndexRange, subpartitionIndexRange);
+                Map<IndexRange, IndexRange> consumedSubpartitionGroups =
+                        inputInfo.getConsumedSubpartitionGroupsInOrder();
+                for (Map.Entry<IndexRange, IndexRange> entry :
+                        consumedSubpartitionGroups.entrySet()) {
+                    IndexRange partitionIndexRange = entry.getKey();
+                    IndexRange subpartitionIndexRange = entry.getValue();
+                    inputBytes +=
+                            blockingResultInfo.getNumBytesProduced(
+                                    partitionIndexRange, subpartitionIndexRange);
+                }
             }
             ev.setInputBytes(inputBytes);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -752,7 +752,7 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
                 BlockingResultInfo blockingResultInfo =
                         checkNotNull(getBlockingResultInfo(intermediateResult.getId()));
                 Map<IndexRange, IndexRange> consumedSubpartitionGroups =
-                        inputInfo.getConsumedSubpartitionGroupsInOrder();
+                        inputInfo.getConsumedSubpartitionGroups();
                 for (Map.Entry<IndexRange, IndexRange> entry :
                         consumedSubpartitionGroups.entrySet()) {
                     IndexRange partitionIndexRange = entry.getKey();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferListener;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.AddCredit;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
@@ -62,10 +63,12 @@ import org.apache.flink.shaded.netty4.io.netty.channel.unix.Errors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.io.network.netty.PartitionRequestQueueTest.blockChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
@@ -84,6 +87,27 @@ import static org.mockito.Mockito.when;
 /** Test for {@link CreditBasedPartitionRequestClientHandler}. */
 class CreditBasedPartitionRequestClientHandlerTest {
 
+    private static Stream<Arguments> bufferDescriptors() {
+        return Stream.of(
+                Arguments.of(false, 1), // Scenario with a regular Buffer
+                Arguments.of(true, 1), // FullyFilledBuffer with 1 partial buffer
+                Arguments.of(true, 3) // FullyFilledBuffer with 3 partial buffers
+                );
+    }
+
+    private static Stream<Arguments> bufferDescriptorsWithCompression() {
+        return Stream.of(
+                Arguments.of(false, 1, "LZ4"),
+                Arguments.of(false, 1, "LZO"),
+                Arguments.of(false, 1, "ZSTD"),
+                Arguments.of(true, 1, "LZ4"),
+                Arguments.of(true, 1, "LZO"),
+                Arguments.of(true, 1, "ZSTD"),
+                Arguments.of(true, 3, "LZ4"),
+                Arguments.of(true, 3, "LZO"),
+                Arguments.of(true, 3, "ZSTD"));
+    }
+
     /**
      * Tests a fix for FLINK-1627.
      *
@@ -95,10 +119,12 @@ class CreditBasedPartitionRequestClientHandlerTest {
      *
      * @see <a href="https://issues.apache.org/jira/browse/FLINK-1627">FLINK-1627</a>
      */
-    @Test
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
     @Timeout(60)
     @SuppressWarnings("unchecked")
-    void testReleaseInputChannelDuringDecode() throws Exception {
+    void testReleaseInputChannelDuringDecode(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         // Mocks an input channel in a state as it was released during a decode.
         final BufferProvider bufferProvider = mock(BufferProvider.class);
         when(bufferProvider.requestBuffer()).thenReturn(null);
@@ -115,7 +141,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
         final BufferResponse receivedBuffer =
                 createBufferResponse(
-                        TestBufferFactory.createBuffer(TestBufferFactory.BUFFER_SIZE),
+                        createBuffer(
+                                isFullyFilled, numOfPartialBuffers, TestBufferFactory.BUFFER_SIZE),
                         0,
                         inputChannel.getInputChannelId(),
                         2,
@@ -129,8 +156,9 @@ class CreditBasedPartitionRequestClientHandlerTest {
      *
      * <p>FLINK-1761 discovered an IndexOutOfBoundsException, when receiving buffers of size 0.
      */
-    @Test
-    void testReceiveEmptyBuffer() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReceiveEmptyBuffer(boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
         // Minimal mock of a remote input channel
         final BufferProvider bufferProvider = mock(BufferProvider.class);
         when(bufferProvider.requestBuffer()).thenReturn(TestBufferFactory.createBuffer(0));
@@ -139,9 +167,6 @@ class CreditBasedPartitionRequestClientHandlerTest {
         when(inputChannel.getInputChannelId()).thenReturn(new InputChannelID());
         when(inputChannel.getBufferProvider()).thenReturn(bufferProvider);
 
-        // An empty buffer of size 0
-        final Buffer emptyBuffer = TestBufferFactory.createBuffer(0);
-
         final CreditBasedPartitionRequestClientHandler client =
                 new CreditBasedPartitionRequestClientHandler();
         client.addInputChannel(inputChannel);
@@ -149,7 +174,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
         final int backlog = 2;
         final BufferResponse receivedBuffer =
                 createBufferResponse(
-                        emptyBuffer,
+                        createBuffer(isFullyFilled, numOfPartialBuffers, 0),
                         0,
                         inputChannel.getInputChannelId(),
                         backlog,
@@ -167,9 +192,11 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * Verifies that {@link RemoteInputChannel#onBuffer(Buffer, int, int, int)} is called when a
      * {@link BufferResponse} is received.
      */
-    @Test
-    void testReceiveBuffer() throws Exception {
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReceiveBuffer(boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, 32 * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         final RemoteInputChannel inputChannel =
                 InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate);
@@ -186,14 +213,14 @@ class CreditBasedPartitionRequestClientHandlerTest {
             final int backlog = 2;
             final BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannel.getInputChannelId(),
                             backlog,
                             new NetworkBufferAllocator(handler));
             handler.channelRead(mock(ChannelHandlerContext.class), bufferResponse);
 
-            assertThat(inputChannel.getNumberOfQueuedBuffers()).isOne();
+            assertThat(inputChannel.getNumberOfQueuedBuffers()).isEqualTo(numOfPartialBuffers);
             assertThat(inputChannel.getSenderBacklog()).isEqualTo(2);
         } finally {
             releaseResource(inputGate, networkBufferPool);
@@ -203,9 +230,14 @@ class CreditBasedPartitionRequestClientHandlerTest {
     /**
      * Verifies that {@link BufferResponse} of compressed {@link Buffer} can be handled correctly.
      */
-    @ParameterizedTest
-    @ValueSource(strings = {"LZ4", "LZO", "ZSTD"})
-    void testReceiveCompressedBuffer(final String compressionCodec) throws Exception {
+    @ParameterizedTest(
+            name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}, compressionCodec={2}")
+    @MethodSource("bufferDescriptorsWithCompression")
+    void testReceiveCompressedBuffer(
+            final boolean isFullyFilled,
+            final int numOfPartialBuffers,
+            final String compressionCodec)
+            throws Exception {
         int bufferSize = 1024;
         BufferCompressor compressor =
                 new BufferCompressor(bufferSize, CompressionCodec.valueOf(compressionCodec));
@@ -229,11 +261,11 @@ class CreditBasedPartitionRequestClientHandlerTest {
                     new CreditBasedPartitionRequestClientHandler();
             handler.addInputChannel(inputChannel);
 
-            Buffer buffer =
-                    compressor.compressToOriginalBuffer(TestBufferFactory.createBuffer(bufferSize));
             BufferResponse bufferResponse =
                     createBufferResponse(
-                            buffer,
+                            compressBuffer(
+                                    compressor,
+                                    createBuffer(isFullyFilled, numOfPartialBuffers, bufferSize)),
                             0,
                             inputChannel.getInputChannelId(),
                             2,
@@ -299,8 +331,10 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * Verifies that {@link RemoteInputChannel#onError(Throwable)} is called when a {@link
      * BufferResponse} is received but no available buffer in input channel.
      */
-    @Test
-    void testThrowExceptionForNoAvailableBuffer() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testThrowExceptionForNoAvailableBuffer(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         final SingleInputGate inputGate = createSingleInputGate(1);
         final RemoteInputChannel inputChannel =
                 spy(InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate));
@@ -315,7 +349,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
         final BufferResponse bufferResponse =
                 createBufferResponse(
-                        TestBufferFactory.createBuffer(TestBufferFactory.BUFFER_SIZE),
+                        createBuffer(
+                                isFullyFilled, numOfPartialBuffers, TestBufferFactory.BUFFER_SIZE),
                         0,
                         inputChannel.getInputChannelId(),
                         2,
@@ -382,8 +417,10 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * and verifies the behaviour of credit notification by triggering channel's writability
      * changed.
      */
-    @Test
-    void testNotifyCreditAvailable() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testNotifyCreditAvailable(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         final CreditBasedPartitionRequestClientHandler handler =
                 new CreditBasedPartitionRequestClientHandler();
         final NetworkBufferAllocator allocator = new NetworkBufferAllocator(handler);
@@ -395,7 +432,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
                         mock(ConnectionID.class),
                         mock(PartitionRequestClientFactory.class));
 
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, 32 * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(2, networkBufferPool);
         final RemoteInputChannel[] inputChannels = new RemoteInputChannel[2];
         inputChannels[0] = createRemoteInputChannel(inputGate, client);
@@ -428,14 +466,14 @@ class CreditBasedPartitionRequestClientHandlerTest {
             // requesting (backlog + numExclusiveBuffers - numAvailableBuffers) floating buffers
             final BufferResponse bufferResponse1 =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannels[0].getInputChannelId(),
                             1,
                             allocator);
             final BufferResponse bufferResponse2 =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannels[1].getInputChannelId(),
                             1,
@@ -468,8 +506,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
             // un-writable channel
             final BufferResponse bufferResponse3 =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
-                            1,
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
+                            numOfPartialBuffers,
                             inputChannels[0].getInputChannelId(),
                             1,
                             allocator);
@@ -508,8 +546,10 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * Verifies that {@link RemoteInputChannel} is enqueued in the pipeline, but {@link AddCredit}
      * message is not sent actually when this input channel is released.
      */
-    @Test
-    void testNotifyCreditAvailableAfterReleased() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testNotifyCreditAvailableAfterReleased(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         final CreditBasedPartitionRequestClientHandler handler =
                 new CreditBasedPartitionRequestClientHandler();
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
@@ -520,7 +560,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
                         mock(ConnectionID.class),
                         mock(PartitionRequestClientFactory.class));
 
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, 32 * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
         try {
@@ -539,7 +580,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
             // Trigger request floating buffers via buffer response to notify credits available
             final BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannel.getInputChannelId(),
                             1,
@@ -564,32 +605,47 @@ class CreditBasedPartitionRequestClientHandlerTest {
         }
     }
 
-    @Test
-    void testReadBufferResponseBeforeReleasingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(false, true);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseBeforeReleasingChannel(
+            boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, false, true, numOfPartialBuffers);
     }
 
-    @Test
-    void testReadBufferResponseBeforeRemovingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(true, true);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseBeforeRemovingChannel(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, true, true, numOfPartialBuffers);
     }
 
-    @Test
-    void testReadBufferResponseAfterReleasingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(false, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseAfterReleasingChannel(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, false, false, numOfPartialBuffers);
     }
 
-    @Test
-    void testReadBufferResponseAfterRemovingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(true, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseAfterRemovingChannel(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, true, false, numOfPartialBuffers);
     }
 
-    @Test
-    void testDoNotFailHandlerOnSingleChannelFailure() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testDoNotFailHandlerOnSingleChannelFailure(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         // Setup
         final int bufferSize = 1024;
         final String expectedMessage = "test exception on buffer";
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, bufferSize * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         final RemoteInputChannel inputChannel =
                 new TestRemoteInputChannelForError(inputGate, expectedMessage);
@@ -604,7 +660,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
             final BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(bufferSize),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, bufferSize),
                             0,
                             inputChannel.getInputChannelId(),
                             1,
@@ -717,11 +773,16 @@ class CreditBasedPartitionRequestClientHandlerTest {
     }
 
     private void testReadBufferResponseWithReleasingOrRemovingChannel(
-            boolean isRemoved, boolean readBeforeReleasingOrRemoving) throws Exception {
+            boolean isFullyFilled,
+            boolean isRemoved,
+            boolean readBeforeReleasingOrRemoving,
+            int numOfPartialBuffers)
+            throws Exception {
 
         int bufferSize = 1024;
 
-        NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
+        NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, bufferSize * numOfPartialBuffers);
         SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         RemoteInputChannel inputChannel = new InputChannelBuilder().buildRemoteChannel(inputGate);
         inputGate.setInputChannels(inputChannel);
@@ -743,7 +804,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
             BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(bufferSize),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, bufferSize),
                             0,
                             inputChannel.getInputChannelId(),
                             1,
@@ -796,17 +857,77 @@ class CreditBasedPartitionRequestClientHandlerTest {
             int backlog,
             NetworkBufferAllocator allocator)
             throws IOException {
-        // Mock buffer to serialize
-        BufferResponse resp =
-                new BufferResponse(buffer, sequenceNumber, receivingChannelId, 0, backlog);
+        // Check if the buffer is an instance of FullyFilledBuffer
+        if (buffer instanceof FullyFilledBuffer) {
+            FullyFilledBuffer fullyFilledBuffer = (FullyFilledBuffer) buffer;
+            int partialBuffers = fullyFilledBuffer.getPartialBuffers().size();
 
-        ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
+            BufferResponse resp =
+                    new BufferResponse(
+                            buffer, sequenceNumber, receivingChannelId, 0, partialBuffers, backlog);
 
-        // Skip general header bytes
-        serialized.readBytes(NettyMessage.FRAME_HEADER_LENGTH);
+            ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
 
-        // Deserialize the bytes to construct the BufferResponse.
-        return BufferResponse.readFrom(serialized, allocator);
+            // Skip general header bytes
+            serialized.readBytes(NettyMessage.FRAME_HEADER_LENGTH);
+
+            // Deserialize the bytes to construct the BufferResponse.
+            BufferResponse bufferResponse = BufferResponse.readFrom(serialized, allocator);
+
+            // Add partial buffer sizes to the response
+            for (Buffer partialBuffer : fullyFilledBuffer.getPartialBuffers()) {
+                bufferResponse.getPartialBufferSizes().add(partialBuffer.getSize());
+            }
+            return bufferResponse;
+        } else {
+            // Construct BufferResponse normally when there are no partial buffers
+            BufferResponse resp =
+                    new BufferResponse(buffer, sequenceNumber, receivingChannelId, 0, 0, backlog);
+
+            ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
+
+            // Skip general header bytes
+            serialized.readBytes(NettyMessage.FRAME_HEADER_LENGTH);
+
+            // Deserialize the bytes to construct the BufferResponse.
+            return BufferResponse.readFrom(serialized, allocator);
+        }
+    }
+
+    private static Buffer createBuffer(
+            boolean isFullyFilled, int numOfPartialBuffers, int bufferSize) {
+        if (!isFullyFilled) {
+            return TestBufferFactory.createBuffer(bufferSize);
+        } else {
+            return createFullyFilledBuffer(numOfPartialBuffers, bufferSize);
+        }
+    }
+
+    private static FullyFilledBuffer createFullyFilledBuffer(
+            int numOfPartialBuffers, int bufferSize) {
+        FullyFilledBuffer buffer =
+                new FullyFilledBuffer(
+                        Buffer.DataType.DATA_BUFFER, bufferSize * numOfPartialBuffers, false);
+
+        for (int i = 0; i < numOfPartialBuffers; i++) {
+            buffer.addPartialBuffer(TestBufferFactory.createBuffer(bufferSize));
+        }
+        return buffer;
+    }
+
+    private static Buffer compressBuffer(BufferCompressor compressor, Buffer buffer) {
+        if (buffer instanceof FullyFilledBuffer) {
+            FullyFilledBuffer fullyFilledBuffer = (FullyFilledBuffer) buffer;
+            FullyFilledBuffer newFullyFilledBuffer =
+                    new FullyFilledBuffer(buffer.getDataType(), buffer.getSize(), true);
+            for (Buffer partialBuffer : fullyFilledBuffer.getPartialBuffers()) {
+                newFullyFilledBuffer.addPartialBuffer(
+                        compressor.compressToOriginalBuffer(partialBuffer));
+            }
+            return newFullyFilledBuffer;
+        } else {
+            return compressor.compressToOriginalBuffer(buffer);
+        }
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.TestingPartitionRequestClient;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
@@ -35,14 +36,16 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.verifyBufferResponseHeader;
@@ -69,11 +72,12 @@ class NettyMessageClientDecoderDelegateTest {
 
     private InputChannelID releasedInputChannelId;
 
-    @BeforeEach
-    void setup() throws IOException, InterruptedException {
+    private void setup(int numOfPartialBuffers) throws IOException, InterruptedException {
         CreditBasedPartitionRequestClientHandler handler =
                 new CreditBasedPartitionRequestClientHandler();
-        networkBufferPool = new NetworkBufferPool(NUMBER_OF_BUFFER_RESPONSES, BUFFER_SIZE);
+        networkBufferPool =
+                new NetworkBufferPool(
+                        NUMBER_OF_BUFFER_RESPONSES, numOfPartialBuffers * BUFFER_SIZE);
         channel = new EmbeddedChannel(new NettyMessageClientDecoderDelegate(handler));
 
         inputGate = createSingleInputGate(1, networkBufferPool);
@@ -110,42 +114,63 @@ class NettyMessageClientDecoderDelegateTest {
         }
     }
 
+    private static Stream<Arguments> bufferDescriptors() {
+        return Stream.of(
+                Arguments.of(false, 1), // Scenario with a regular Buffer
+                Arguments.of(true, 1), // FullyFilledBuffer with 1 partial buffer
+                Arguments.of(true, 3) // FullyFilledBuffer with 3 partial buffers
+                );
+    }
+
     /** Verifies that the client side decoder works well for unreleased input channels. */
-    @Test
-    void testClientMessageDecode() throws Exception {
-        testNettyMessageClientDecoding(false, false, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecode(boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, false, false, false);
     }
 
     /**
      * Verifies that the client side decoder works well for empty buffers. Empty buffers should not
      * consume data buffers of the input channels.
      */
-    @Test
-    void testClientMessageDecodeWithEmptyBuffers() throws Exception {
-        testNettyMessageClientDecoding(true, false, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecodeWithEmptyBuffers(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, true, false, false);
     }
 
     /**
      * Verifies that the client side decoder works well with buffers sent to a released input
      * channel. The data buffer part should be discarded before reading the next message.
      */
-    @Test
-    void testClientMessageDecodeWithReleasedInputChannel() throws Exception {
-        testNettyMessageClientDecoding(false, true, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecodeWithReleasedInputChannel(
+            boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, false, true, false);
     }
 
     /**
      * Verifies that the client side decoder works well with buffers sent to a removed input
      * channel. The data buffer part should be discarded before reading the next message.
      */
-    @Test
-    void testClientMessageDecodeWithRemovedInputChannel() throws Exception {
-        testNettyMessageClientDecoding(false, false, true);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecodeWithRemovedInputChannel(
+            boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, false, false, true);
     }
 
     // ------------------------------------------------------------------------------------------------------------------
 
     private void testNettyMessageClientDecoding(
+            boolean isFullyFilled,
+            int numOfPartialBuffers,
             boolean hasEmptyBuffer,
             boolean hasBufferForReleasedChannel,
             boolean hasBufferForRemovedChannel)
@@ -156,6 +181,8 @@ class NettyMessageClientDecoderDelegateTest {
         try {
             List<BufferResponse> messages =
                     createMessageList(
+                            isFullyFilled,
+                            numOfPartialBuffers,
                             hasEmptyBuffer,
                             hasBufferForReleasedChannel,
                             hasBufferForRemovedChannel);
@@ -179,6 +206,8 @@ class NettyMessageClientDecoderDelegateTest {
     }
 
     private List<BufferResponse> createMessageList(
+            boolean isFullyFilled,
+            int numOfPartialBuffers,
             boolean hasEmptyBuffer,
             boolean hasBufferForRemovedChannel,
             boolean hasBufferForReleasedChannel) {
@@ -188,6 +217,8 @@ class NettyMessageClientDecoderDelegateTest {
 
         for (int i = 0; i < NUMBER_OF_BUFFER_RESPONSES - 1; i++) {
             addBufferResponse(
+                    isFullyFilled,
+                    numOfPartialBuffers,
                     messages,
                     inputChannelId,
                     Buffer.DataType.DATA_BUFFER,
@@ -197,10 +228,18 @@ class NettyMessageClientDecoderDelegateTest {
 
         if (hasEmptyBuffer) {
             addBufferResponse(
-                    messages, inputChannelId, Buffer.DataType.DATA_BUFFER, 0, seqNumber++);
+                    isFullyFilled,
+                    numOfPartialBuffers,
+                    messages,
+                    inputChannelId,
+                    Buffer.DataType.DATA_BUFFER,
+                    0,
+                    seqNumber++);
         }
         if (hasBufferForReleasedChannel) {
             addBufferResponse(
+                    isFullyFilled,
+                    numOfPartialBuffers,
                     messages,
                     releasedInputChannelId,
                     Buffer.DataType.DATA_BUFFER,
@@ -209,6 +248,8 @@ class NettyMessageClientDecoderDelegateTest {
         }
         if (hasBufferForRemovedChannel) {
             addBufferResponse(
+                    isFullyFilled,
+                    numOfPartialBuffers,
                     messages,
                     new InputChannelID(),
                     Buffer.DataType.DATA_BUFFER,
@@ -216,32 +257,80 @@ class NettyMessageClientDecoderDelegateTest {
                     seqNumber++);
         }
 
-        addBufferResponse(messages, inputChannelId, Buffer.DataType.EVENT_BUFFER, 32, seqNumber++);
         addBufferResponse(
-                messages, inputChannelId, Buffer.DataType.DATA_BUFFER, BUFFER_SIZE, seqNumber);
+                isFullyFilled,
+                numOfPartialBuffers,
+                messages,
+                inputChannelId,
+                Buffer.DataType.EVENT_BUFFER,
+                32,
+                seqNumber++);
+        addBufferResponse(
+                isFullyFilled,
+                numOfPartialBuffers,
+                messages,
+                inputChannelId,
+                Buffer.DataType.DATA_BUFFER,
+                BUFFER_SIZE,
+                seqNumber);
 
         return messages;
     }
 
     private void addBufferResponse(
+            boolean isFullyFilled,
+            int numOfPartialBuffers,
             List<BufferResponse> messages,
             InputChannelID inputChannelId,
             Buffer.DataType dataType,
             int bufferSize,
             int seqNumber) {
 
-        Buffer buffer = createDataBuffer(bufferSize, dataType);
-        messages.add(new BufferResponse(buffer, seqNumber, inputChannelId, 0, 1));
+        Buffer buffer = createDataBuffer(isFullyFilled, numOfPartialBuffers, bufferSize, dataType);
+        BufferResponse bufferResponse =
+                new BufferResponse(
+                        buffer,
+                        seqNumber,
+                        inputChannelId,
+                        0,
+                        isFullyFilled ? numOfPartialBuffers : 0,
+                        1);
+        if (isFullyFilled) {
+            for (int i = 0; i < numOfPartialBuffers; i++) {
+                bufferResponse.getPartialBufferSizes().add(bufferSize);
+            }
+        }
+        messages.add(bufferResponse);
     }
 
-    private Buffer createDataBuffer(int size, Buffer.DataType dataType) {
-        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
-        NetworkBuffer buffer = new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, dataType);
-        for (int i = 0; i < size / 4; ++i) {
-            buffer.writeInt(i);
-        }
+    private Buffer createDataBuffer(
+            boolean isFullyFilled, int numOfPartialBuffers, int size, Buffer.DataType dataType) {
+        if (!isFullyFilled) {
+            MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
+            NetworkBuffer buffer =
+                    new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, dataType);
+            for (int i = 0; i < size / 4; ++i) {
+                buffer.writeInt(i);
+            }
 
-        return buffer;
+            return buffer;
+        } else {
+            FullyFilledBuffer fullyFilledBuffer =
+                    new FullyFilledBuffer(dataType, numOfPartialBuffers * size, false);
+
+            for (int i = 0; i < numOfPartialBuffers; i++) {
+                MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
+                NetworkBuffer buffer =
+                        new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, dataType);
+                for (int num = 0; num < size / 4; ++num) {
+                    buffer.writeInt(num);
+                }
+
+                fullyFilledBuffer.addPartialBuffer(buffer);
+            }
+
+            return fullyFilledBuffer;
+        }
     }
 
     private ByteBuf[] encodeMessages(List<BufferResponse> messages) throws Exception {
@@ -334,7 +423,12 @@ class NettyMessageClientDecoderDelegateTest {
             if (expected.bufferSize == 0 || !expected.receiverId.equals(inputChannelId)) {
                 assertThat(actual.getBuffer()).isNull();
             } else {
-                assertThat(actual.getBuffer()).isEqualTo(expected.getBuffer());
+                Buffer buffer = expected.getBuffer();
+                if (buffer instanceof FullyFilledBuffer) {
+                    assertThat(actual.getBuffer()).isEqualTo(buffer.asByteBuf());
+                } else {
+                    assertThat(actual.getBuffer()).isEqualTo(buffer);
+                }
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
@@ -188,6 +188,7 @@ class NettyMessageClientSideSerializationTest {
                         testBuffer,
                         random.nextInt(Integer.MAX_VALUE),
                         inputChannelId,
+                        0,
                         random.nextInt(Integer.MAX_VALUE),
                         random.nextInt(Integer.MAX_VALUE));
         BufferResponse actual = encodeAndDecode(expected, channel);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
@@ -188,8 +188,8 @@ class NettyMessageClientSideSerializationTest {
                         testBuffer,
                         random.nextInt(Integer.MAX_VALUE),
                         inputChannelId,
-                        0,
                         random.nextInt(Integer.MAX_VALUE),
+                        0,
                         random.nextInt(Integer.MAX_VALUE));
         BufferResponse actual = encodeAndDecode(expected, channel);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorSer
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,7 +96,7 @@ class SortMergeResultPartitionReadSchedulerTest {
         fileReader =
                 new PartitionedFileReader(
                         partitionedFile,
-                        0,
+                        new ResultSubpartitionIndexSet(0),
                         dataFileChannel,
                         indexFileChannel,
                         BufferReaderWriterUtil.allocatedHeaderBuffer(),
@@ -125,7 +126,9 @@ class SortMergeResultPartitionReadSchedulerTest {
 
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
-                        new NoOpBufferAvailablityListener(), 0, partitionedFile);
+                        new NoOpBufferAvailablityListener(),
+                        new ResultSubpartitionIndexSet(0),
+                        partitionedFile);
 
         assertThat(readScheduler.isRunning()).isTrue();
         assertThat(readScheduler.getDataFileChannel().isOpen()).isTrue();
@@ -140,8 +143,13 @@ class SortMergeResultPartitionReadSchedulerTest {
             if (bufferAndBacklog != null) {
                 int numBytes = bufferAndBacklog.buffer().readableBytes();
                 MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(numBytes);
+
+                FullyFilledBuffer fullyFilledBuffer = (FullyFilledBuffer) bufferAndBacklog.buffer();
+
+                assertThat(fullyFilledBuffer.getPartialBuffers().size()).isOne();
                 Buffer fullBuffer =
-                        ((CompositeBuffer) bufferAndBacklog.buffer()).getFullBufferData(segment);
+                        ((CompositeBuffer) fullyFilledBuffer.getPartialBuffers().get(0))
+                                .getFullBufferData(segment);
                 assertThat(ByteBuffer.wrap(dataBytes)).isEqualTo(fullBuffer.getNioBufferReadable());
                 fullBuffer.recycleBuffer();
                 ++numBuffersRead;
@@ -153,7 +161,9 @@ class SortMergeResultPartitionReadSchedulerTest {
     void testOnSubpartitionReaderError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
-                        new NoOpBufferAvailablityListener(), 0, partitionedFile);
+                        new NoOpBufferAvailablityListener(),
+                        new ResultSubpartitionIndexSet(0),
+                        partitionedFile);
 
         subpartitionReader.releaseAllResources();
         waitUntilReadFinish();
@@ -164,7 +174,9 @@ class SortMergeResultPartitionReadSchedulerTest {
     void testReleaseWhileReading() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
-                        new NoOpBufferAvailablityListener(), 0, partitionedFile);
+                        new NoOpBufferAvailablityListener(),
+                        new ResultSubpartitionIndexSet(0),
+                        partitionedFile);
 
         Thread.sleep(1000);
         readScheduler.release();
@@ -185,7 +197,9 @@ class SortMergeResultPartitionReadSchedulerTest {
         assertThatThrownBy(
                         () ->
                                 readScheduler.createSubpartitionReader(
-                                        new NoOpBufferAvailablityListener(), 0, partitionedFile))
+                                        new NoOpBufferAvailablityListener(),
+                                        new ResultSubpartitionIndexSet(0),
+                                        partitionedFile))
                 .isInstanceOf(IllegalStateException.class);
         assertAllResourcesReleased();
     }
@@ -194,7 +208,9 @@ class SortMergeResultPartitionReadSchedulerTest {
     void testOnDataReadError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
-                        new NoOpBufferAvailablityListener(), 0, partitionedFile);
+                        new NoOpBufferAvailablityListener(),
+                        new ResultSubpartitionIndexSet(0),
+                        partitionedFile);
 
         // close file channel to trigger data read exception
         readScheduler.getDataFileChannel().close();
@@ -222,7 +238,9 @@ class SortMergeResultPartitionReadSchedulerTest {
                         bufferPool, schedulerExecutor, new Object());
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
-                        new NoOpBufferAvailablityListener(), 0, partitionedFile);
+                        new NoOpBufferAvailablityListener(),
+                        new ResultSubpartitionIndexSet(0),
+                        partitionedFile);
         bufferPool.destroy();
         assertThat(schedulerExecutor.numQueuedRunnables()).isEqualTo(1);
         // we should trigger the scheduled task to handle the buffer request error.
@@ -241,7 +259,8 @@ class SortMergeResultPartitionReadSchedulerTest {
     void testNoDeadlockWhenReadAndReleaseBuffers() throws Exception {
         bufferPool.initialize();
         SortMergeSubpartitionReader subpartitionReader =
-                new SortMergeSubpartitionReader(new NoOpBufferAvailablityListener(), fileReader);
+                new SortMergeSubpartitionReader(
+                        bufferSize, new NoOpBufferAvailablityListener(), fileReader);
         Thread readAndReleaseThread =
                 new Thread(
                         () -> {
@@ -276,7 +295,9 @@ class SortMergeResultPartitionReadSchedulerTest {
                         bufferPool, executorService, this, bufferRequestTimeout);
         long startTimestamp = System.currentTimeMillis();
         readScheduler.createSubpartitionReader(
-                new NoOpBufferAvailablityListener(), 0, partitionedFile);
+                new NoOpBufferAvailablityListener(),
+                new ResultSubpartitionIndexSet(0),
+                partitionedFile);
         // request and use all buffers of buffer pool.
         readScheduler.run();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReaderTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.util.IOUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -137,8 +138,13 @@ class SortMergeSubpartitionReaderTest {
                     checkNotNull(subpartitionReader.getNextBuffer());
             int numBytes = bufferAndBacklog.buffer().readableBytes();
             MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(numBytes);
+
+            FullyFilledBuffer fullyFilledBuffer = (FullyFilledBuffer) bufferAndBacklog.buffer();
+            assertThat(fullyFilledBuffer.getPartialBuffers().size()).isOne();
             Buffer fullBuffer =
-                    ((CompositeBuffer) bufferAndBacklog.buffer()).getFullBufferData(segment);
+                    ((CompositeBuffer) fullyFilledBuffer.getPartialBuffers().get(0))
+                            .getFullBufferData(segment);
+
             assertThat(ByteBuffer.wrap(dataBytes)).isEqualTo(fullBuffer.getNioBufferReadable());
             assertThat(bufferAndBacklog.buffersInBacklog()).isEqualTo(i == 0 ? 0 : i - 1);
             Buffer.DataType dataType = i <= 1 ? Buffer.DataType.NONE : Buffer.DataType.DATA_BUFFER;
@@ -237,13 +243,13 @@ class SortMergeSubpartitionReaderTest {
         PartitionedFileReader fileReader =
                 new PartitionedFileReader(
                         partitionedFile,
-                        0,
+                        new ResultSubpartitionIndexSet(0),
                         dataFileChannel,
                         indexFileChannel,
                         BufferReaderWriterUtil.allocatedHeaderBuffer(),
                         createAndConfigIndexEntryBuffer());
         assertThat(fileReader.hasRemaining()).isTrue();
-        return new SortMergeSubpartitionReader(listener, fileReader);
+        return new SortMergeSubpartitionReader(bufferSize, listener, fileReader);
     }
 
     private static FileChannel openFileChannel(Path path) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -947,7 +947,8 @@ class SingleInputGateTest extends InputGateTestBase {
                         netEnv,
                         localLocation,
                         new TestingConnectionManager(),
-                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()));
+                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()),
+                        partitionIds.length);
 
         for (InputChannel channel : gate.inputChannels()) {
             if (channel instanceof ChannelStateHolder) {
@@ -960,8 +961,7 @@ class SingleInputGateTest extends InputGateTestBase {
                             getInputChannelsInPartition(gate, partitionIds[i]).stream()
                                     .map(InputChannel::getConsumedSubpartitionIndexSet)
                                     .collect(Collectors.toList()))
-                    .containsExactlyInAnyOrder(
-                            new ResultSubpartitionIndexSet(0), new ResultSubpartitionIndexSet(1));
+                    .containsExactly(new ResultSubpartitionIndexSet(new IndexRange(0, 1)));
         }
 
         assertChannelsType(gate, LocalRecoveredInputChannel.class, partitionIds[0]);
@@ -1263,7 +1263,8 @@ class SingleInputGateTest extends InputGateTestBase {
                         netEnv,
                         ResourceID.generate(),
                         new TestingConnectionManager(),
-                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()));
+                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()),
+                        partitionIds.length * subpartitionRandSize);
         gate.setup();
 
         for (InputChannel inputChannel : gate.inputChannels()) {
@@ -1323,7 +1324,8 @@ class SingleInputGateTest extends InputGateTestBase {
                 netEnv,
                 ResourceID.generate(),
                 null,
-                null);
+                null,
+                partitionIds.length);
     }
 
     static SingleInputGate createSingleInputGate(
@@ -1333,25 +1335,29 @@ class SingleInputGateTest extends InputGateTestBase {
             NettyShuffleEnvironment netEnv,
             ResourceID localLocation,
             ConnectionManager connectionManager,
-            ResultPartitionManager resultPartitionManager)
+            ResultPartitionManager resultPartitionManager,
+            int numOfChannels)
             throws IOException {
 
-        ShuffleDescriptorAndIndex[] channelDescs =
-                new ShuffleDescriptorAndIndex[] {
-                    // Local
-                    new ShuffleDescriptorAndIndex(
-                            createRemoteWithIdAndLocation(partitionIds[0], localLocation), 0),
-                    // Remote
-                    new ShuffleDescriptorAndIndex(
-                            createRemoteWithIdAndLocation(partitionIds[1], ResourceID.generate()),
-                            1),
-                    // Unknown
+        ShuffleDescriptorAndIndex[] channelDescs = new ShuffleDescriptorAndIndex[numOfChannels];
+
+        // Local
+        channelDescs[0] =
+                new ShuffleDescriptorAndIndex(
+                        createRemoteWithIdAndLocation(partitionIds[0], localLocation), 0);
+        // Remote
+        channelDescs[1] =
+                new ShuffleDescriptorAndIndex(
+                        createRemoteWithIdAndLocation(partitionIds[1], ResourceID.generate()), 1);
+        // Unknown
+        for (int i = 2; i < numOfChannels; i++) {
+            channelDescs[i] =
                     new ShuffleDescriptorAndIndex(
                             new UnknownShuffleDescriptor(
                                     new ResultPartitionID(
                                             partitionIds[2], createExecutionAttemptId())),
-                            2)
-                };
+                            i);
+        }
 
         InputGateDeploymentDescriptor gateDesc =
                 new InputGateDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -167,9 +167,8 @@ class SsgNetworkMemoryCalculationUtilsTest {
                 slotSharingGroups,
                 Arrays.asList(
                         new MemorySize(TestShuffleMaster.computeRequiredShuffleMemoryBytes(0, 5)),
-                        new MemorySize(TestShuffleMaster.computeRequiredShuffleMemoryBytes(5, 20)),
-                        new MemorySize(
-                                TestShuffleMaster.computeRequiredShuffleMemoryBytes(15, 0))));
+                        new MemorySize(TestShuffleMaster.computeRequiredShuffleMemoryBytes(1, 20)),
+                        new MemorySize(TestShuffleMaster.computeRequiredShuffleMemoryBytes(5, 0))));
     }
 
     private void triggerComputeNumOfSubpartitions(IntermediateResult result) {
@@ -192,14 +191,14 @@ class SsgNetworkMemoryCalculationUtilsTest {
 
     @Test
     void testGetMaxInputChannelNumForResultForAllToAll() throws Exception {
-        testGetMaxInputChannelNumForResult(DistributionPattern.ALL_TO_ALL, 5, 20, 7, 15);
+        testGetMaxInputChannelNumForResult(DistributionPattern.ALL_TO_ALL, 5, 20, 7, 5);
     }
 
     @Test
     void testGetMaxInputChannelNumForResultForPointWise() throws Exception {
-        testGetMaxInputChannelNumForResult(DistributionPattern.POINTWISE, 5, 20, 3, 8);
-        testGetMaxInputChannelNumForResult(DistributionPattern.POINTWISE, 5, 20, 5, 4);
-        testGetMaxInputChannelNumForResult(DistributionPattern.POINTWISE, 5, 20, 7, 4);
+        testGetMaxInputChannelNumForResult(DistributionPattern.POINTWISE, 5, 20, 3, 2);
+        testGetMaxInputChannelNumForResult(DistributionPattern.POINTWISE, 5, 20, 5, 1);
+        testGetMaxInputChannelNumForResult(DistributionPattern.POINTWISE, 5, 20, 7, 1);
     }
 
     private void testGetMaxInputChannelNumForResult(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
